### PR TITLE
Fix PostCSS configuration for Next.js build

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,8 +1,8 @@
+import tailwindcss from "tailwindcss";
+import autoprefixer from "autoprefixer";
+
 const config = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {}
-  }
+  plugins: [tailwindcss, autoprefixer]
 };
 
 export default config;


### PR DESCRIPTION
## Summary
- update PostCSS config to use explicit Tailwind CSS and Autoprefixer plugins

## Testing
- pnpm run build *(fails: network error fetching Inter font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68e46f8b7d58832e82fbc29183506550