### PR TITLE
Fix typed routes for header and footer navigation

### DIFF
--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -14,7 +14,7 @@ type FooterLinkGroup = {
   items: FooterLinkItem[];
 };
 
-const footerLinks: FooterLinkGroup[] = [
+const footerLinks = [
   {
     title: "Showroom",
     items: siteConfig.locations.map((location) => ({
@@ -34,11 +34,11 @@ const footerLinks: FooterLinkGroup[] = [
     title: "Support",
     items: [
       { label: "Contact", href: "/contact" },
-      { label: "FAQ", href: "/resources#faq" },
+      { label: "FAQ", href: { pathname: "/resources", hash: "faq" } },
       { label: "Policies", href: "/legal" }
     ]
   }
-];
+] satisfies FooterLinkGroup[];
 
 export function SiteFooter() {
   const phoneHref = siteConfig.contact.phone.replace(/[^\d+]/g, "");

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { Route } from "next";
 import Link from "next/link";
 import { Menu, Phone } from "lucide-react";
 import { useState } from "react";
@@ -16,7 +17,7 @@ const navigation = [
   { href: "/about", label: "About" },
   { href: "/contact", label: "Contact" },
   { href: "/blog", label: "Blog" }
-];
+] as const satisfies readonly { href: Route; label: string }[];
 
 export function SiteHeader() {
   const [isOpen, setIsOpen] = useState(false);
@@ -44,10 +45,10 @@ export function SiteHeader() {
           ))}
         </nav>
         <div className="hidden items-center gap-4 lg:flex">
-          <Link href={`tel:${phoneHref}`} className="flex items-center gap-2 text-sm font-semibold text-slate-900">
+          <a href={`tel:${phoneHref}`} className="flex items-center gap-2 text-sm font-semibold text-slate-900">
             <Phone className="h-4 w-4" />
             <span>{siteConfig.contact.phone}</span>
-          </Link>
+          </a>
           <Link
             href="/contact"
             className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-700"
@@ -81,10 +82,10 @@ export function SiteHeader() {
               {item.label}
             </Link>
           ))}
-          <Link href={`tel:${phoneHref}`} className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900">
+          <a href={`tel:${phoneHref}`} className="inline-flex items-center gap-2 text-sm font-semibold text-slate-900">
             <Phone className="h-4 w-4" />
             <span>{siteConfig.contact.phone}</span>
-          </Link>
+          </a>
           <Link
             href="/contact"
             className="inline-flex items-center justify-center rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white"


### PR DESCRIPTION
## Summary
- narrow the site header navigation typing so Next.js typedRoutes accepts each link and swap telephone links to anchors
- tighten the footer navigation typing and use a UrlObject for the FAQ link so hashes comply with typedRoutes

## Testing
- pnpm lint *(fails: command prompts for interactive ESLint setup in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e55b3897ac832e95b446d540024a98