### PR TITLE
Ensure CTA links satisfy typed routes

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,7 +120,7 @@ export default function HomePage() {
         title="Let's design a surface story unique to your home."
         description="Book a complimentary consultation at our Florida showroom or virtual appointment to explore collections, review budgets, and align on timelines."
         primaryCta={{ href: "/contact", label: "Request consultation" }}
-        secondaryCta={{ href: `tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`, label: "Call the showroom" }}
+        secondaryCta={{ href: `tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`, label: "Call the showroom", isExternal: true }}
       />
     </>
   );

--- a/src/components/sections/cta.tsx
+++ b/src/components/sections/cta.tsx
@@ -1,13 +1,20 @@
 import Link from "next/link";
+import type { Route } from "next";
 
 import { Container } from "../ui/container";
+
+type InternalCta = { href: Route; label: string };
+type ExternalCta = { href: string; label: string; isExternal: true };
 
 interface CtaSectionProps {
   title: string;
   description: string;
-  primaryCta: { href: string; label: string };
-  secondaryCta?: { href: string; label: string };
+  primaryCta: InternalCta;
+  secondaryCta?: InternalCta | ExternalCta;
 }
+
+const isExternalLink = (cta: InternalCta | ExternalCta): cta is ExternalCta =>
+  "isExternal" in cta && cta.isExternal;
 
 export function CtaSection({ title, description, primaryCta, secondaryCta }: CtaSectionProps) {
   return (
@@ -25,14 +32,22 @@ export function CtaSection({ title, description, primaryCta, secondaryCta }: Cta
               >
                 {primaryCta.label}
               </Link>
-              {secondaryCta && (
-                <Link
-                  href={secondaryCta.href}
-                  className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
-                >
-                  {secondaryCta.label}
-                </Link>
-              )}
+              {secondaryCta &&
+                (isExternalLink(secondaryCta) ? (
+                  <a
+                    href={secondaryCta.href}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                  >
+                    {secondaryCta.label}
+                  </a>
+                ) : (
+                  <Link
+                    href={secondaryCta.href}
+                    className="inline-flex items-center justify-center rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:text-slate-900"
+                  >
+                    {secondaryCta.label}
+                  </Link>
+                ))}
             </div>
           </div>
           <div className="relative h-full min-h-[240px] rounded-2xl bg-[radial-gradient(circle_at_top_left,#f8fafc,transparent_70%),linear-gradient(120deg,#334155,#0f172a)]" aria-hidden />

--- a/src/components/sections/hero.tsx
+++ b/src/components/sections/hero.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import type { Route } from "next";
 
 import { Container } from "../ui/container";
 
@@ -6,8 +7,8 @@ interface HeroSectionProps {
   eyebrow: string;
   title: string;
   description: string;
-  primaryCta: { label: string; href: string };
-  secondaryCta: { label: string; href: string };
+  primaryCta: { label: string; href: Route };
+  secondaryCta: { label: string; href: Route };
 }
 
 export function HeroSection({ eyebrow, title, description, primaryCta, secondaryCta }: HeroSectionProps) {


### PR DESCRIPTION
## Summary
- tighten the CTA section props to use Next.js typed routes and allow explicit external links
- mark the CTA telephone link as external so it renders with a standard anchor
- align the hero section CTA props with typed route expectations

## Testing
- `pnpm lint` *(fails: Next.js interactive lint configuration prompt in CI)*

------
https://chatgpt.com/codex/tasks/task_e_68e579802590832eb482c185f42d6be3