### PR TITLE
Switch logo to transparent variant

### DIFF
--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -26,7 +26,7 @@ export function Logo({
       aria-label="Fleitz Family Tile Home"
     >
       <Image
-        src="/images/Fleitz-Logo-on-White.png"
+        src="/images/Fleitz-Family-Tile-Logo.png"
         alt="Fleitz Family Tile Logo"
         width={width}
         height={height}


### PR DESCRIPTION
## Summary
- update the shared Logo component to use the transparent logo asset so it no longer shows a white background

## Testing
- pnpm dev *(fails to download Inter font in offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a5e48f68832e9031bb6af980a9c6