### PR TITLE
Restructure site pages to mirror reference site layout

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,27 +1,30 @@
 import { Container } from "@/components/ui/container";
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
 import { PageHeader } from "@/components/sections/page-header";
 
-const milestones = [
+const values = [
   {
-    year: "1994",
-    title: "Family beginnings",
-    description: "Fleitz Family Tile opened its first Florida showroom with a focus on craftsmanship and personalized service."
+    title: "Family-led service",
+    description:
+      "From your first consultation to final walkthrough, you work directly with a family-owned team that values clear communication and accountability."
   },
   {
-    year: "2005",
-    title: "Installation teams expand",
-    description: "We added licensed crews and project managers to deliver turnkey tile installations across the region."
+    title: "Craftsmanship without compromise",
+    description:
+      "Licensed installers follow detailed prep standards, waterproofing methods, and finishing techniques refined over decades."
   },
   {
-    year: "2016",
-    title: "Design studio upgrade",
-    description: "The showroom evolved into an appointment-driven design center with curated vignettes and private sampling rooms."
-  },
-  {
-    year: "Today",
-    title: "Trusted by homeowners & builders",
-    description: "Our family-led team continues to support renovations, new construction, and commercial environments throughout Florida."
+    title: "Design-forward guidance",
+    description:
+      "Our showroom consultants curate palettes that balance trend-forward aesthetics with timeless appeal and everyday durability."
   }
+];
+
+const credentials = [
+  "Licensed and insured tile contractors",
+  "Schluter®-trained waterproofing installers",
+  "Certified to handle large-format porcelain and natural stone",
+  "Trusted trade partner for builders across the Gulf Coast"
 ];
 
 export default function AboutPage() {
@@ -29,28 +32,51 @@ export default function AboutPage() {
     <>
       <PageHeader
         eyebrow="About"
-        title="Family-owned tile expertise grounded in craftsmanship and service."
-        description="For decades, Fleitz Family Tile has paired curated surfaces with skilled installers to help Floridians elevate their homes and businesses."
+        title="A Bradenton family dedicated to tile and stone excellence."
+        description="Fleitz Family Tile combines a neighborhood showroom with meticulous installation teams, helping homeowners, designers, and builders create inviting spaces throughout Florida."
       />
+
       <section className="py-16">
-        <Container className="grid gap-12 lg:grid-cols-[minmax(0,0.7fr)_minmax(0,1fr)]">
+        <Container className="grid gap-12 lg:grid-cols-[minmax(0,1.1fr)_minmax(0,0.9fr)]">
           <div className="space-y-6">
-            <h2 className="text-2xl font-semibold text-slate-900">Our philosophy</h2>
-            <p className="text-sm leading-relaxed text-slate-600">
-              We believe tile should be both beautiful and enduring. That means guiding clients through selections that balance design vision with daily performance, then installing every surface with uncompromising detail.
+            <h2 className="text-3xl font-semibold text-slate-900">Our story</h2>
+            <p className="text-base leading-relaxed text-slate-600">
+              What began as a small installation crew has grown into a full-service showroom and project management team. The Fleitz family built the business on trust—showing up when promised, finishing details with care, and standing behind every installation long after the grout cures.
             </p>
-            <p className="text-sm leading-relaxed text-slate-600">
-              As a family-run company, relationships matter. We invest in long-term partnerships with homeowners, designers, and builders by staying transparent, responsive, and accountable at every stage.
+            <p className="text-base leading-relaxed text-slate-600">
+              Today, we guide clients through material selections, provide transparent proposals, and coordinate licensed craftsmen who respect your home or jobsite. Whether it's a single-room refresh or a multi-phase commercial build, you can expect the same attentive experience.
+            </p>
+            <div className="grid gap-4 sm:grid-cols-2">
+              {values.map((value) => (
+                <article key={value.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <h3 className="text-lg font-semibold text-slate-900">{value.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600">{value.description}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+          <PlaceholderImage className="h-full min-h-[400px] w-full" />
+        </Container>
+      </section>
+
+      <section className="bg-slate-100 py-16">
+        <Container className="grid gap-10 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <h2 className="text-2xl font-semibold text-slate-900">Dedicated to your project timeline</h2>
+            <p className="text-base text-slate-600">
+              We treat every home as if it were our own. Our project coordinators provide updates throughout demolition, prep, installation, and finishing so you always know what happens next.
+            </p>
+            <p className="text-base text-slate-600">
+              The crew tidies job sites daily, protects adjacent surfaces, and inspects each installation against our internal checklist before presenting the finished space.
             </p>
           </div>
-          <div className="space-y-4">
-            <h2 className="text-2xl font-semibold text-slate-900">Milestones</h2>
-            <ul className="space-y-4">
-              {milestones.map((milestone) => (
-                <li key={milestone.year} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-                  <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">{milestone.year}</span>
-                  <h3 className="mt-2 text-lg font-semibold text-slate-900">{milestone.title}</h3>
-                  <p className="mt-2 text-sm text-slate-600">{milestone.description}</p>
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+            <h3 className="text-lg font-semibold text-slate-900">Credentials & partnerships</h3>
+            <ul className="mt-4 space-y-3 text-sm text-slate-600">
+              {credentials.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-slate-900" aria-hidden />
+                  <span>{item}</span>
                 </li>
               ))}
             </ul>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,47 +2,64 @@ import { siteConfig } from "@/config/site";
 import { ContactForm } from "@/components/sections/contact-form";
 import { PageHeader } from "@/components/sections/page-header";
 import { Container } from "@/components/ui/container";
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
 
 export default function ContactPage() {
   return (
     <>
       <PageHeader
         eyebrow="Contact"
-        title="Schedule a consultation or request a proposal."
-        description="We respond within one business day. Visit our Florida showroom or request a virtual design session."
+        title="Connect with Fleitz Family Tile."
+        description="Share your project goals, schedule a showroom visit, or request an on-site consultation. Our team responds within one business day."
       />
-      <section className="bg-slate-100 py-16">
-        <Container className="grid gap-12 lg:grid-cols-2">
-          <div className="space-y-6">
-            <h2 className="text-2xl font-semibold text-slate-900">Showroom details</h2>
-            <p className="text-sm leading-relaxed text-slate-600">
-              {siteConfig.locations[0]?.address}
-              <br />
-              {siteConfig.locations[0]?.city}
-            </p>
-            <div className="space-y-2 text-sm text-slate-600">
-              <p>
-                <span className="font-semibold text-slate-900">Phone:</span> {siteConfig.contact.phone}
+      <section className="py-16">
+        <Container className="grid gap-12 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+          <div className="space-y-8">
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold text-slate-900">Showroom & contact details</h2>
+              <p className="text-sm leading-relaxed text-slate-600">
+                Visit our Bradenton head office to browse tile collections, review design inspirations, and discuss timelines with our team.
               </p>
-              <p>
-                <span className="font-semibold text-slate-900">Email:</span> {siteConfig.contact.email}
-              </p>
-              <p>
-                <span className="font-semibold text-slate-900">Hours:</span>
-                <br />
-                {siteConfig.hours.weekdays}
-                <br />
-                {siteConfig.hours.saturday}
-                <br />
-                {siteConfig.hours.sunday}
-              </p>
+              <div className="space-y-3 text-sm text-slate-600">
+                <p>
+                  <span className="font-semibold text-slate-900">Address:</span>
+                  <br />
+                  {siteConfig.locations[0]?.address}
+                  <br />
+                  {siteConfig.locations[0]?.city}
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900">Phone:</span>{" "}
+                  <a href={`tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`} className="text-slate-900 underline-offset-4 hover:underline">
+                    {siteConfig.contact.phone}
+                  </a>
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900">Email:</span>{" "}
+                  <a href={`mailto:${siteConfig.contact.email}`} className="text-slate-900 underline-offset-4 hover:underline">
+                    {siteConfig.contact.email}
+                  </a>
+                </p>
+                <p>
+                  <span className="font-semibold text-slate-900">Hours:</span>
+                  <br />
+                  {siteConfig.hours.weekdays}
+                  <br />
+                  {siteConfig.hours.saturday}
+                  <br />
+                  {siteConfig.hours.sunday}
+                </p>
+              </div>
             </div>
+            <PlaceholderImage className="h-64 w-full" label="Image Here" />
           </div>
           <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
             <div className="space-y-2 pb-6">
-              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Connect</span>
-              <h2 className="text-2xl font-semibold text-slate-900">Share your project details.</h2>
-              <p className="text-sm text-slate-600">Submit the form and our concierge team will respond within one business day.</p>
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Request information</span>
+              <h2 className="text-2xl font-semibold text-slate-900">Tell us about your project</h2>
+              <p className="text-sm text-slate-600">
+                Share your project scope, location, and timeline. We'll follow up with next steps and schedule a consultation.
+              </p>
             </div>
             <ContactForm />
           </div>

--- a/app/gallery/page.tsx
+++ b/app/gallery/page.tsx
@@ -1,0 +1,59 @@
+import { PageHeader } from "@/components/sections/page-header";
+import { Container } from "@/components/ui/container";
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
+
+const gallerySections = [
+  {
+    title: "Kitchen transformations",
+    description: "Backsplashes, islands, and flooring showcasing tailored patterns and textures.",
+    items: ["Coastal quartz backsplash", "Waterfall island detail", "Herringbone feature wall"]
+  },
+  {
+    title: "Bath & spa retreats",
+    description: "Curbless showers, soaking tubs, and statement vanities with waterproofed tile systems.",
+    items: ["Marble-inspired shower", "Textured niche accents", "Freestanding tub surround"]
+  },
+  {
+    title: "Outdoor living",
+    description: "Lanai, patio, and pool deck installations designed for Florida's climate.",
+    items: ["Slip-resistant pool deck", "Summer kitchen backsplash", "Covered lanai flooring"]
+  },
+  {
+    title: "Commercial spaces",
+    description: "Lobbies, wellness centers, and retail environments crafted for durability and style.",
+    items: ["Boutique lobby", "Wellness spa waiting area", "Modern retail flooring"]
+  }
+];
+
+export default function GalleryPage() {
+  return (
+    <>
+      <PageHeader
+        eyebrow="Gallery"
+        title="Inspiration from recent tile and stone installations."
+        description="Explore a sampling of the textures, layouts, and finishing touches completed by Fleitz Family Tile. Visit the showroom to browse additional project imagery and material swatches."
+      />
+
+      <section className="py-16">
+        <Container className="space-y-12">
+          {gallerySections.map((section) => (
+            <div key={section.title} className="space-y-6">
+              <div className="space-y-2 text-center">
+                <h2 className="text-2xl font-semibold text-slate-900">{section.title}</h2>
+                <p className="mx-auto max-w-2xl text-sm text-slate-600">{section.description}</p>
+              </div>
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                {section.items.map((item) => (
+                  <article key={item} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+                    <PlaceholderImage className="h-44 w-full" />
+                    <p className="text-sm font-semibold text-slate-900">{item}</p>
+                  </article>
+                ))}
+              </div>
+            </div>
+          ))}
+        </Container>
+      </section>
+    </>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,127 +1,312 @@
-import { CtaSection } from "@/components/sections/cta";
-import { FaqSection } from "@/components/sections/faq";
-import { HeroSection } from "@/components/sections/hero";
-import { ProcessSection } from "@/components/sections/process";
-import { ServiceGallery } from "@/components/sections/service-gallery";
-import { TestimonialsSection } from "@/components/sections/testimonials";
-import { ValuePropsSection } from "@/components/sections/value-props";
+import Link from "next/link";
+import { ArrowRight, CheckCircle2, Mail, MapPin, Phone } from "lucide-react";
+
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
+import { Container } from "@/components/ui/container";
 import { siteConfig } from "@/config/site";
 
-const serviceCategories = [
+const serviceHighlights = [
   {
-    title: "Luxury Residential",
-    description: "Complete surface packages for kitchens, baths, outdoor living, and specialty rooms.",
-    bullets: [
-      "Porcelain & ceramic flooring systems",
-      "Waterproof shower assemblies",
-      "Pool & lanai tile upgrades"
-    ]
+    title: "Custom tile design studio",
+    description:
+      "Work one-on-one with our designers to choose surfaces for kitchens, bathrooms, flooring, pools, and outdoor living areas."
   },
   {
-    title: "Design Studio",
-    description: "Collaborate with our design consultants to craft palettes tailored to your architecture.",
-    bullets: [
-      "Private slab-viewing appointments",
-      "Custom mosaic design",
-      "Material sampling & take-home boards"
-    ]
+    title: "Licensed installation crews",
+    description:
+      "Experienced craftsmen handle demolition, surface prep, waterproofing, and precise installation for lasting performance."
   },
   {
-    title: "Commercial & Trade",
-    description: "Dedicated project management for hospitality, multifamily, and custom builder partners.",
-    bullets: [
-      "Specification support",
-      "Logistics & warehousing",
-      "Site coordination & punch services"
-    ]
+    title: "Project coordination",
+    description:
+      "From material ordering to punch-list walkthroughs, our team keeps your remodel or new build on schedule and on budget."
   }
 ];
 
-const valueProps = [
+const featuredServices = [
   {
-    title: "Curated Showroom Experience",
-    description: "Navigate hundreds of surface options organized by style, color story, and performance—all guided by a seasoned design team."
+    title: "Kitchen & bath remodels",
+    description: "Backsplashes, showers, tubs, and floors finished with resilient grout systems and detailed trim work."
   },
   {
-    title: "Licensed Installation Teams",
-    description: "Our tile artisans deliver meticulous installation, waterproofing, and finishing to meet Florida building standards."
+    title: "Whole-home flooring",
+    description: "Large-format porcelain, natural stone, and luxury plank layouts tailored to open-concept living."
   },
   {
-    title: "Builder & Designer Partnerships",
-    description: "We integrate with your construction schedules, provide detailed takeoffs, and communicate proactively with trade partners."
+    title: "Outdoor & pool decks",
+    description: "Slip-resistant selections for lanais, patios, summer kitchens, and pool waterlines built for the Florida climate."
   },
   {
-    title: "Concierge Project Support",
-    description: "Expect proactive updates, transparent pricing, and a dedicated point of contact from ordering through final walkthrough."
+    title: "Commercial environments",
+    description: "Lobby, restaurant, and wellness spaces supported with documentation, logistics, and phased installation plans."
   }
+];
+
+const galleryPreview = [
+  "Spa-inspired primary bath",
+  "Statement kitchen backsplash",
+  "Coastal outdoor retreat",
+  "Custom mosaic fireplace",
+  "Modern lobby renovation",
+  "Luxury condo flooring"
 ];
 
 const processSteps = [
   {
-    step: "Step 01",
-    title: "Vision & discovery",
-    description: "We map out your goals, architectural style, and investment level, then assemble inspiration palettes tailored to the space."
+    title: "Showroom consultation",
+    description:
+      "Discuss your vision, review inspiration photos, and explore curated palettes during a guided visit or virtual appointment."
   },
   {
-    step: "Step 02",
     title: "Material curation",
-    description: "Your consultant sources samples, secures lead times, and finalizes specifications with precise quantities."
+    description:
+      "We source samples, confirm availability, and provide detailed proposals with timelines and investment options."
   },
   {
-    step: "Step 03",
-    title: "Installation logistics",
-    description: "Our project management team coordinates delivery windows, staging, and qualified installation crews."
-  },
-  {
-    step: "Step 04",
-    title: "Final detailing",
-    description: "We finish with protective sealing, punch-list touchups, and handover documentation so you can enjoy the finished space."
+    title: "Installation & detailing",
+    description:
+      "Licensed tile setters prepare surfaces, install with precision, and finish with sealers and care instructions."
   }
 ];
 
 const testimonials = [
   {
-    quote: "The design team narrowed hundreds of options into a cohesive plan that perfectly fit our waterfront home.",
-    name: "Jordan & Casey L.",
-    project: "Coastal renovation"
+    quote:
+      "Fleitz Family Tile handled our entire remodel—from design choices to installation. The team was punctual, courteous, and the tile work is flawless.",
+    name: "Megan & Aaron P.",
+    location: "Bradenton, FL"
   },
   {
-    quote: "Reliable communication and craftsmanship—we trust them with every model home we build in the region.",
-    name: "Harborline Developments",
-    project: "Builder partnership"
-  },
-  {
-    quote: "Installation was meticulous down to the last mosaic. Our spa clients rave about the finished space.",
-    name: "Solstice Wellness",
-    project: "Commercial spa"
+    quote:
+      "As a builder, communication matters. Their crews stayed on schedule and delivered model homes that wowed our buyers.",
+    name: "Gulfside Homes",
+    location: "Sarasota, FL"
   }
 ];
 
 export default function HomePage() {
   return (
     <>
-      <HeroSection
-        eyebrow="Florida's Tile Authority"
-        title="Showroom design and expert installation for elevated surfaces."
-        description="Fleitz Family Tile pairs curated materials with precision installation for homeowners, designers, and builders seeking statement-worthy floors, walls, and outdoor living in Florida."
-        primaryCta={{ href: "/contact", label: "Schedule a consultation" }}
-        secondaryCta={{ href: "/marketplace", label: "Browse surfaces" }}
-      />
-      <ValuePropsSection
-        title="From product selection to white-glove installation, our team handles every layer of your tile project."
-        description="We pair a design-forward showroom with a veteran field team so you can confidently transform kitchens, baths, and outdoor spaces with timeless materials."
-        items={valueProps}
-      />
-      <ServiceGallery categories={serviceCategories} />
-      <ProcessSection steps={processSteps} />
-      <TestimonialsSection testimonials={testimonials} />
-      <FaqSection />
-      <CtaSection
-        title="Let's design a surface story unique to your home."
-        description="Book a complimentary consultation at our Florida showroom or virtual appointment to explore collections, review budgets, and align on timelines."
-        primaryCta={{ href: "/contact", label: "Request consultation" }}
-        secondaryCta={{ href: `tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`, label: "Call the showroom", isExternal: true }}
-      />
+      <section className="border-b border-slate-200 bg-gradient-to-b from-white to-slate-100/60 py-16">
+        <Container className="grid items-center gap-12 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.85fr)]">
+          <div className="space-y-6">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Tile & stone experts</span>
+            <h1 className="text-4xl font-semibold text-slate-900 sm:text-5xl">
+              Design-forward tile and stone crafted for Florida living.
+            </h1>
+            <p className="max-w-xl text-base leading-relaxed text-slate-600">
+              Fleitz Family Tile pairs a Bradenton showroom with licensed installers to deliver refined surfaces for homes,
+              remodelers, and commercial partners across the Gulf Coast.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/contact"
+                className="inline-flex items-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+              >
+                Schedule a consultation
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+              <Link
+                href="/services"
+                className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-900 hover:text-slate-900"
+              >
+                Explore services
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </div>
+            <div className="grid gap-4 text-sm text-slate-600 sm:grid-cols-3">
+              <div className="rounded-3xl border border-slate-200 bg-white p-4">
+                <p className="font-semibold text-slate-900">Serving the Gulf Coast</p>
+                <p>Bradenton · Sarasota · Lakewood Ranch · Anna Maria Island</p>
+              </div>
+              <div className="rounded-3xl border border-slate-200 bg-white p-4">
+                <p className="font-semibold text-slate-900">Family owned & operated</p>
+                <p>Decades of craftsmanship and concierge-level service.</p>
+              </div>
+              <div className="rounded-3xl border border-slate-200 bg-white p-4">
+                <p className="font-semibold text-slate-900">Licensed & insured</p>
+                <p>Professional crews equipped for remodels and new builds.</p>
+              </div>
+            </div>
+          </div>
+          <PlaceholderImage className="h-full min-h-[320px] w-full" />
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container className="grid gap-8 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-semibold text-slate-900">Showroom guidance. Field precision.</h2>
+            <p className="text-base leading-relaxed text-slate-600">
+              Every project begins with listening. Whether you\'re refreshing a bathroom, planning a custom home, or managing a
+              commercial build, our consultants curate surfaces that balance aesthetic goals with daily durability. From there,
+              licensed installers execute every detail—waterproofing, layouts, trims, and finishes—for results that stand up to
+              Florida\'s climate.
+            </p>
+            <div className="space-y-4">
+              {serviceHighlights.map((highlight) => (
+                <div key={highlight.title} className="flex gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <CheckCircle2 className="mt-1 h-6 w-6 text-slate-900" aria-hidden />
+                  <div>
+                    <p className="text-base font-semibold text-slate-900">{highlight.title}</p>
+                    <p className="mt-1 text-sm text-slate-600">{highlight.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          <PlaceholderImage className="h-full min-h-[420px] w-full" />
+        </Container>
+      </section>
+
+      <section className="bg-slate-100 py-16">
+        <Container>
+          <div className="space-y-10">
+            <div className="space-y-3 text-center">
+              <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Services</span>
+              <h2 className="text-3xl font-semibold text-slate-900">Tile solutions for every room.</h2>
+              <p className="mx-auto max-w-2xl text-sm text-slate-600">
+                From demolition to final sealant, our crews manage kitchens, baths, flooring, and specialty spaces with the same
+                care we bring to our own family homes.
+              </p>
+            </div>
+            <div className="grid gap-6 md:grid-cols-2">
+              {featuredServices.map((service) => (
+                <article key={service.title} className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <PlaceholderImage className="h-40 w-full" />
+                  <div>
+                    <h3 className="text-lg font-semibold text-slate-900">{service.title}</h3>
+                    <p className="mt-2 text-sm text-slate-600">{service.description}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container className="space-y-10">
+          <div className="space-y-3 text-center">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Portfolio preview</span>
+            <h2 className="text-3xl font-semibold text-slate-900">Imagine the possibilities.</h2>
+            <p className="mx-auto max-w-2xl text-sm text-slate-600">
+              Explore a sampling of the installations and design pairings clients love. Visit the gallery to see more transformations.
+            </p>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {galleryPreview.map((item) => (
+              <div key={item} className="space-y-3 rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+                <PlaceholderImage className="h-40 w-full" />
+                <p className="text-sm font-semibold text-slate-900">{item}</p>
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-center">
+            <Link
+              href="/gallery"
+              className="inline-flex items-center gap-2 rounded-full border border-slate-300 px-6 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-900 hover:text-slate-900"
+            >
+              View full gallery
+              <ArrowRight className="h-4 w-4" aria-hidden />
+            </Link>
+          </div>
+        </Container>
+      </section>
+
+      <section className="bg-slate-900 py-16 text-slate-100">
+        <Container className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-300">Our process</span>
+            <h2 className="text-3xl font-semibold text-white">Guided from idea to installation.</h2>
+            <p className="text-sm text-slate-300">
+              Expect proactive updates, organized project management, and meticulous workmanship at every phase of the journey.
+            </p>
+          </div>
+          <div className="space-y-6">
+            {processSteps.map((step, index) => (
+              <div key={step.title} className="rounded-3xl border border-slate-700 bg-slate-800/60 p-6">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Step {index + 1}</p>
+                <h3 className="mt-2 text-lg font-semibold text-white">{step.title}</h3>
+                <p className="mt-2 text-sm text-slate-300">{step.description}</p>
+              </div>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      <section className="py-16">
+        <Container className="space-y-10">
+          <div className="space-y-3 text-center">
+            <span className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Testimonials</span>
+            <h2 className="text-3xl font-semibold text-slate-900">Kind words from our clients.</h2>
+            <p className="mx-auto max-w-2xl text-sm text-slate-600">
+              See why homeowners, designers, and builders rely on Fleitz Family Tile for detail-driven tile and stone installations.
+            </p>
+          </div>
+          <div className="grid gap-6 lg:grid-cols-2">
+            {testimonials.map((testimonial) => (
+              <blockquote key={testimonial.quote} className="h-full rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+                <p className="text-base italic text-slate-700">“{testimonial.quote}”</p>
+                <footer className="mt-6 text-sm font-semibold text-slate-900">
+                  {testimonial.name}
+                  <span className="block text-xs font-normal uppercase tracking-[0.3em] text-slate-500">
+                    {testimonial.location}
+                  </span>
+                </footer>
+              </blockquote>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      <section className="bg-slate-100 py-16">
+        <Container className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-semibold text-slate-900">Visit our Bradenton showroom.</h2>
+            <p className="text-base text-slate-600">
+              Share your project goals, browse materials, and receive a detailed plan from our concierge team. We respond to inquiries within one business day.
+            </p>
+            <div className="space-y-3 text-sm text-slate-600">
+              <p className="flex items-start gap-3">
+                <MapPin className="mt-1 h-5 w-5" aria-hidden />
+                <span>
+                  {siteConfig.locations[0]?.address}
+                  <br />
+                  {siteConfig.locations[0]?.city}
+                </span>
+              </p>
+              <p className="flex items-center gap-3">
+                <Phone className="h-5 w-5" aria-hidden />
+                <a href={`tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`} className="font-semibold text-slate-900 hover:underline">
+                  {siteConfig.contact.phone}
+                </a>
+              </p>
+              <p className="flex items-center gap-3">
+                <Mail className="h-5 w-5" aria-hidden />
+                <a href={`mailto:${siteConfig.contact.email}`} className="font-semibold text-slate-900 hover:underline">
+                  {siteConfig.contact.email}
+                </a>
+              </p>
+            </div>
+          </div>
+          <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+            <h3 className="text-lg font-semibold text-slate-900">Request a consultation</h3>
+            <p className="mt-2 text-sm text-slate-600">
+              Tell us about timelines, inspirations, and the spaces you\'re upgrading. We\'ll schedule a visit or virtual walk-through.
+            </p>
+            <div className="mt-6">
+              <Link
+                href="/contact"
+                className="inline-flex w-full items-center justify-center gap-2 rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+              >
+                Start the conversation
+                <ArrowRight className="h-4 w-4" aria-hidden />
+              </Link>
+            </div>
+          </div>
+        </Container>
+      </section>
     </>
   );
 }

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,46 +1,55 @@
-import { ContentGrid } from "@/components/sections/content-grid";
 import { PageHeader } from "@/components/sections/page-header";
+import { Container } from "@/components/ui/container";
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
 
-const services = [
+const servicePackages = [
   {
-    title: "Residential transformations",
+    title: "Kitchen tile & backsplashes",
     description:
-      "Tailored tile packages for kitchens, baths, main flooring, and outdoor living spaces with an emphasis on lasting performance.",
-    bullets: [
-      "Design consultations and 3D concept support",
-      "Waterproofing and heated-floor solutions",
-      "Dedicated project managers for remodels"
-    ]
+      "Full demolition, surface preparation, and installation for custom backsplashes, islands, and flooring with precise trim details."
   },
   {
-    title: "Custom builder program",
+    title: "Bathroom & shower systems",
     description:
-      "Surface packages engineered for production and semi-custom builders seeking reliable schedules and standout model homes.",
-    bullets: [
-      "Specification documentation and takeoffs",
-      "Model merchandising and buyer upgrade paths",
-      "Trade coordination and punch services"
-    ]
+      "Waterproofed showers, soaking tubs, and vanities finished with mosaics, niches, benches, and heated flooring options."
   },
   {
-    title: "Commercial environments",
+    title: "Whole-home flooring",
     description:
-      "Tile sourcing and installation for lobbies, amenities, restaurants, medical suites, and hospitality properties across Florida.",
-    bullets: [
-      "Large-format porcelain slab handling",
-      "Slip-resistant and antimicrobial selections",
-      "Night and phased installation options"
-    ]
+      "Large-format porcelain, luxury plank, and natural stone layouts aligned to architectural sightlines and transitions."
   },
   {
-    title: "Specialty fabrication",
+    title: "Outdoor living & pools",
     description:
-      "Custom mosaics, feature walls, fireplace surrounds, and waterline details fabricated in-house for a precise fit on-site.",
-    bullets: [
-      "Waterjet cutting and pattern layout",
-      "Edge profiling and miters",
-      "Sample boards and finish mockups"
-    ]
+      "Lanais, patios, and pool decks built with slip-resistant tiles, coping, and waterline details engineered for Florida weather."
+  },
+  {
+    title: "Commercial & builder partnerships",
+    description:
+      "Specification support, model merchandising, and phased installations for hospitality, multifamily, and retail environments."
+  },
+  {
+    title: "Custom features & accents",
+    description:
+      "Fireplaces, feature walls, stair risers, and mosaics fabricated to size with miters, profiles, and edge treatments."
+  }
+];
+
+const serviceSteps = [
+  {
+    title: "Consultation & measurement",
+    description:
+      "We visit your home or jobsite to capture measurements, discuss scope, and gather inspiration that informs product curation."
+  },
+  {
+    title: "Material selection & proposal",
+    description:
+      "Our team assembles samples, creates mood boards, and delivers a detailed scope outlining labor, materials, and scheduling."
+  },
+  {
+    title: "Project management & installation",
+    description:
+      "Licensed installers execute demolition, prep, tile setting, and finishing while coordinators provide updates from start to finish."
   }
 ];
 
@@ -49,10 +58,54 @@ export default function ServicesPage() {
     <>
       <PageHeader
         eyebrow="Services"
-        title="White-glove tile services for homes, builders, and commercial spaces."
-        description="Bring your designs to life with a showroom stocked for inspiration and field crews equipped for excellence."
+        title="Comprehensive tile services tailored to your space."
+        description="From concept to completion, Fleitz Family Tile delivers curated materials, precise craftsmanship, and proactive communication for every project."
       />
-      <ContentGrid sections={services} />
+
+      <section className="py-16">
+        <Container className="space-y-10">
+          <div className="space-y-3 text-center">
+            <h2 className="text-3xl font-semibold text-slate-900">What we install</h2>
+            <p className="mx-auto max-w-2xl text-sm text-slate-600">
+              Whether you are refreshing a single room or coordinating a multi-home development, our team manages demolition, prep, installation, and finishing with a detail-driven approach.
+            </p>
+          </div>
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {servicePackages.map((service) => (
+              <article key={service.title} className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                <PlaceholderImage className="h-36 w-full" />
+                <div>
+                  <h3 className="text-lg font-semibold text-slate-900">{service.title}</h3>
+                  <p className="mt-2 text-sm text-slate-600">{service.description}</p>
+                </div>
+              </article>
+            ))}
+          </div>
+        </Container>
+      </section>
+
+      <section className="bg-slate-100 py-16">
+        <Container className="grid gap-10 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-semibold text-slate-900">Working with Fleitz Family Tile</h2>
+            <p className="text-base leading-relaxed text-slate-600">
+              Our coordinators handle scheduling, material logistics, and crew management so your project stays organized. You receive regular updates and walk every step with a dedicated point of contact.
+            </p>
+            <p className="text-base leading-relaxed text-slate-600">
+              We collaborate with interior designers, builders, and homeowners, providing transparent pricing and craftsmanship that respects your timelines and budget.
+            </p>
+          </div>
+          <div className="space-y-6">
+            {serviceSteps.map((step, index) => (
+              <article key={step.title} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Phase {index + 1}</p>
+                <h3 className="mt-2 text-lg font-semibold text-slate-900">{step.title}</h3>
+                <p className="mt-2 text-sm text-slate-600">{step.description}</p>
+              </article>
+            ))}
+          </div>
+        </Container>
+      </section>
     </>
   );
 }

--- a/app/testimonials/page.tsx
+++ b/app/testimonials/page.tsx
@@ -1,0 +1,86 @@
+import { PageHeader } from "@/components/sections/page-header";
+import { Container } from "@/components/ui/container";
+
+const testimonials = [
+  {
+    quote:
+      "We remodeled our entire first floor with Fleitz Family Tile. Their team protected our home, stayed on schedule, and delivered beautiful floors and showers.",
+    name: "Jessica & Mark L.",
+    location: "Bradenton, FL"
+  },
+  {
+    quote:
+      "As a designer, I rely on partners who can execute complex layouts. Fleitz Family Tile understands vision boards and brings them to life.",
+    name: "Studio Marina Design",
+    location: "Sarasota, FL"
+  },
+  {
+    quote:
+      "From the first consultation to the final seal, communication was clear. The workmanship in our spa is exceptional and our clients notice the difference.",
+    name: "Solstice Wellness",
+    location: "Lakewood Ranch, FL"
+  },
+  {
+    quote:
+      "Our production builds demand consistency. Their crews deliver punch-list ready homes that impress our buyers every time.",
+    name: "Harborline Builders",
+    location: "Manatee County, FL"
+  }
+];
+
+const assurances = [
+  "Licensed and insured tile installers",
+  "In-house project coordination and scheduling",
+  "Transparent proposals with detailed line items",
+  "Clean job sites and respectful crews"
+];
+
+export default function TestimonialsPage() {
+  return (
+    <>
+      <PageHeader
+        eyebrow="Testimonials"
+        title="Trusted by homeowners, designers, and builders across Florida."
+        description="Hear from clients who rely on Fleitz Family Tile for detailed installations and dependable service on every project."
+      />
+
+      <section className="py-16">
+        <Container className="grid gap-10 lg:grid-cols-[minmax(0,1fr)_minmax(0,0.8fr)]">
+          <div className="space-y-6">
+            <h2 className="text-3xl font-semibold text-slate-900">What clients are saying</h2>
+            <div className="space-y-6">
+              {testimonials.map((testimonial) => (
+                <blockquote key={testimonial.quote} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <p className="text-base italic text-slate-700">“{testimonial.quote}”</p>
+                  <footer className="mt-4 text-sm font-semibold text-slate-900">
+                    {testimonial.name}
+                    <span className="block text-xs font-normal uppercase tracking-[0.3em] text-slate-500">
+                      {testimonial.location}
+                    </span>
+                  </footer>
+                </blockquote>
+              ))}
+            </div>
+          </div>
+          <div className="space-y-6 rounded-3xl border border-slate-200 bg-slate-100 p-8">
+            <h3 className="text-xl font-semibold text-slate-900">Why professionals choose Fleitz Family Tile</h3>
+            <p className="text-sm text-slate-600">
+              Our process is built to support designers, contractors, and homeowners with proactive coordination and workmanship that stands up to daily use.
+            </p>
+            <ul className="space-y-3 text-sm text-slate-600">
+              {assurances.map((item) => (
+                <li key={item} className="flex items-start gap-2">
+                  <span className="mt-1 h-1.5 w-1.5 rounded-full bg-slate-900" aria-hidden />
+                  <span>{item}</span>
+                </li>
+              ))}
+            </ul>
+            <p className="text-sm text-slate-600">
+              Ready to experience the difference? <span className="font-semibold text-slate-900">Schedule a consultation</span> to tour the showroom and review your project goals.
+            </p>
+          </div>
+        </Container>
+      </section>
+    </>
+  );
+}

--- a/src/components/layout/site-footer.tsx
+++ b/src/components/layout/site-footer.tsx
@@ -1,44 +1,74 @@
 import Link from "next/link";
+import { Mail, MapPin, Phone } from "lucide-react";
 
 import { Logo } from "@/components/ui/logo";
 import { navigation } from "@/config/navigation";
+import { siteConfig } from "@/config/site";
 
 export function SiteFooter() {
   const currentYear = new Date().getFullYear();
 
   return (
-    <footer className="border-t bg-gray-50">
+    <footer className="border-t bg-slate-900 text-slate-100">
       <div className="mx-auto max-w-7xl px-4 py-12 sm:px-6 lg:px-8 lg:py-16">
-        <div className="xl:grid xl:grid-cols-3 xl:gap-8">
-          <div className="space-y-8">
-            <Logo width={120} height={120} />
-            <p className="text-sm text-gray-500">
-              Providing high-quality tile installation services throughout Florida.
+        <div className="grid gap-12 lg:grid-cols-[minmax(0,0.8fr)_minmax(0,1fr)]">
+          <div className="space-y-6">
+            <Logo width={200} height={70} />
+            <p className="max-w-sm text-sm text-slate-300">
+              Fleitz Family Tile delivers showroom guidance and expert installation for homes and businesses throughout the Gulf Coast.
             </p>
+            <div className="space-y-3 text-sm text-slate-300">
+              <p className="flex items-start gap-2">
+                <MapPin className="mt-1 h-4 w-4" aria-hidden />
+                <span>
+                  {siteConfig.locations[0]?.address}
+                  <br />
+                  {siteConfig.locations[0]?.city}
+                </span>
+              </p>
+              <p className="flex items-center gap-2">
+                <Phone className="h-4 w-4" aria-hidden />
+                <a href={`tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`} className="hover:underline">
+                  {siteConfig.contact.phone}
+                </a>
+              </p>
+              <p className="flex items-center gap-2">
+                <Mail className="h-4 w-4" aria-hidden />
+                <a href={`mailto:${siteConfig.contact.email}`} className="hover:underline">
+                  {siteConfig.contact.email}
+                </a>
+              </p>
+            </div>
           </div>
-
-          <div className="mt-12 grid grid-cols-2 gap-8 xl:col-span-2 xl:mt-0">
+          <div className="grid gap-12 sm:grid-cols-2">
             <div>
-              <h3 className="text-sm font-semibold uppercase tracking-wider text-gray-900">
-                Company
-              </h3>
-              <ul className="mt-4 space-y-4">
+              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white">Navigation</h3>
+              <ul className="mt-4 space-y-3 text-sm text-slate-300">
                 {navigation.map((item) => (
                   <li key={item.label}>
-                    <Link href={item.href} className="text-sm text-gray-500 hover:text-gray-900">
+                    <Link href={item.href} className="transition hover:text-white">
                       {item.label}
                     </Link>
                   </li>
                 ))}
               </ul>
             </div>
+            <div>
+              <h3 className="text-sm font-semibold uppercase tracking-[0.3em] text-white">Showroom Hours</h3>
+              <ul className="mt-4 space-y-2 text-sm text-slate-300">
+                <li>{siteConfig.hours.weekdays}</li>
+                <li>{siteConfig.hours.saturday}</li>
+                <li>{siteConfig.hours.sunday}</li>
+              </ul>
+              <p className="mt-6 text-sm text-slate-300">
+                Proudly serving Bradenton, Sarasota, Lakewood Ranch, and the Greater Tampa Bay region.
+              </p>
+            </div>
           </div>
         </div>
 
-        <div className="mt-12 border-t border-gray-200 pt-8">
-          <p className="text-sm text-gray-500">
-            &copy; {currentYear} Fleitz Family Tile. All rights reserved.
-          </p>
+        <div className="mt-12 border-t border-slate-700 pt-8 text-sm text-slate-400">
+          <p>&copy; {currentYear} Fleitz Family Tile. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -1,22 +1,42 @@
-'use client';
+"use client";
 
 import Link from "next/link";
-import { Menu } from "lucide-react";
+import { Menu, Mail, Phone } from "lucide-react";
 
 import { Logo } from "@/components/ui/logo";
 import { navigation } from "@/config/navigation";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetClose, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { siteConfig } from "@/config/site";
 
 export function SiteHeader() {
   return (
     <header className="sticky top-0 z-40 w-full border-b bg-white">
+      <div className="hidden bg-slate-900 text-xs text-white sm:block">
+        <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-2 sm:px-6 lg:px-8">
+          <div className="flex items-center gap-4">
+            <span className="inline-flex items-center gap-2">
+              <Phone className="h-3.5 w-3.5" aria-hidden />
+              <a href={`tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`} className="hover:underline">
+                {siteConfig.contact.phone}
+              </a>
+            </span>
+            <span className="inline-flex items-center gap-2">
+              <Mail className="h-3.5 w-3.5" aria-hidden />
+              <a href={`mailto:${siteConfig.contact.email}`} className="hover:underline">
+                {siteConfig.contact.email}
+              </a>
+            </span>
+          </div>
+          <span className="hidden md:block">Serving Bradenton, Sarasota, and surrounding Gulf Coast communities.</span>
+        </div>
+      </div>
       <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex lg:flex-1">
-          <Logo width={100} height={100} priority />
+          <Logo width={180} height={60} />
         </div>
 
-        <nav className="hidden items-center gap-8 text-sm font-medium text-slate-600 lg:flex">
+        <nav className="hidden items-center gap-8 text-sm font-semibold text-slate-600 lg:flex">
           {navigation.map((item) => (
             <Link key={item.href} href={item.href} className="transition hover:text-slate-900">
               {item.label}
@@ -29,7 +49,7 @@ export function SiteHeader() {
             href="/contact"
             className="hidden rounded-full bg-slate-900 px-6 py-2 text-sm font-semibold text-white transition hover:bg-slate-700 sm:inline-flex"
           >
-            Get a Quote
+            Schedule Consultation
           </Link>
 
           <Sheet>
@@ -40,18 +60,29 @@ export function SiteHeader() {
               </Button>
             </SheetTrigger>
             <SheetContent side="right">
-              <nav className="mt-8 grid gap-4">
-                {navigation.map((item) => (
-                  <SheetClose key={item.href} asChild>
-                    <Link
-                      href={item.href}
-                      className="text-base font-medium text-slate-600 transition hover:text-slate-900"
-                    >
-                      {item.label}
-                    </Link>
-                  </SheetClose>
-                ))}
-              </nav>
+              <div className="space-y-6 pt-6">
+                <div className="space-y-2 text-sm text-slate-600">
+                  <p className="font-semibold text-slate-900">Contact</p>
+                  <a href={`tel:${siteConfig.contact.phone.replace(/[^\d+]/g, "")}`} className="block">
+                    {siteConfig.contact.phone}
+                  </a>
+                  <a href={`mailto:${siteConfig.contact.email}`} className="block">
+                    {siteConfig.contact.email}
+                  </a>
+                </div>
+                <nav className="grid gap-4">
+                  {navigation.map((item) => (
+                    <SheetClose key={item.href} asChild>
+                      <Link
+                        href={item.href}
+                        className="text-base font-medium text-slate-600 transition hover:text-slate-900"
+                      >
+                        {item.label}
+                      </Link>
+                    </SheetClose>
+                  ))}
+                </nav>
+              </div>
             </SheetContent>
           </Sheet>
         </div>

--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -1,13 +1,13 @@
-import Image from "next/image";
 import Link from "next/link";
 import type { Route } from "next";
+
+import { PlaceholderImage } from "@/components/ui/placeholder-image";
 
 interface LogoProps {
   href?: Route;
   className?: string;
   width?: number;
   height?: number;
-  priority?: boolean;
 }
 
 const homeRoute: Route = "/";
@@ -15,9 +15,8 @@ const homeRoute: Route = "/";
 export function Logo({
   href = homeRoute,
   className = "",
-  width = 150,
-  height = 150,
-  priority = false
+  width = 180,
+  height = 60
 }: LogoProps) {
   return (
     <Link
@@ -25,13 +24,10 @@ export function Logo({
       className={`inline-block ${className}`}
       aria-label="Fleitz Family Tile Home"
     >
-      <Image
-        src="/images/Fleitz-Family-Tile-Logo.png"
-        alt="Fleitz Family Tile Logo"
-        width={width}
-        height={height}
-        priority={priority}
-        className="h-auto w-auto"
+      <PlaceholderImage
+        className="flex items-center justify-center rounded-none border-2 border-slate-900 bg-slate-50"
+        label="Image Here"
+        style={{ width, height }}
       />
     </Link>
   );

--- a/src/components/ui/placeholder-image.tsx
+++ b/src/components/ui/placeholder-image.tsx
@@ -1,0 +1,27 @@
+import type { HTMLAttributes } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PlaceholderImageProps extends HTMLAttributes<HTMLDivElement> {
+  label?: string;
+}
+
+export function PlaceholderImage({ label = "Image Here", className, style, ...props }: PlaceholderImageProps) {
+  return (
+    <div
+      className={cn(
+        "relative overflow-hidden rounded-lg border-2 border-dashed border-slate-300 bg-white",
+        className
+      )}
+      style={style}
+      {...props}
+    >
+      <div className="absolute inset-x-0 top-0 flex justify-center">
+        <span className="mt-2 rounded-full bg-white px-3 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.3em] text-slate-500">
+          {label}
+        </span>
+      </div>
+      <div className="h-full w-full pt-8" aria-hidden />
+    </div>
+  );
+}

--- a/src/config/navigation.ts
+++ b/src/config/navigation.ts
@@ -1,11 +1,10 @@
 import type { Route } from "next";
 
 export const navigation = [
-  { href: "/services", label: "Services" },
-  { href: "/buyers", label: "Buyers" },
-  { href: "/marketplace", label: "Marketplace" },
-  { href: "/resources", label: "Resources" },
+  { href: "/" as Route, label: "Home" },
   { href: "/about", label: "About" },
-  { href: "/contact", label: "Contact" },
-  { href: "/blog", label: "Blog" }
+  { href: "/services", label: "Services" },
+  { href: "/gallery", label: "Gallery" },
+  { href: "/testimonials", label: "Testimonials" },
+  { href: "/contact", label: "Contact" }
 ] as const satisfies readonly { href: Route; label: string }[];

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -11,14 +11,14 @@ export const siteConfig = {
   url: "https://www.fleitzfamilytile.com",
   ogImage: "/images/branding/og-image.jpg",
   contact: {
-    phone: "(000) 000-0000",
-    email: "info@fleitzfamilytile.com"
+    phone: "502-714-0544",
+    email: "fleitzfamilytile@gmail.com"
   },
   locations: [
     {
-      label: "Primary Showroom",
-      address: "Update with verified street address",
-      city: "Florida (update with city)",
+      label: "Head Office",
+      address: "4504 22nd Ave W",
+      city: "Bradenton, FL 34209",
       coordinates: null
     }
   ],


### PR DESCRIPTION
## Summary
- update the navigation, header, and footer to mirror the reference site structure and contact details
- rewrite home, about, services, and contact pages and add gallery/testimonials pages using placeholder imagery
- add a reusable placeholder image block and update the logo component to display the placeholder art

## Testing
- pnpm lint *(fails: Next.js prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5a7f87a7c832e9aeae3e694b47025