### PR TITLE
Fix navigation item type guard

### DIFF
--- a/src/components/layout/site-header.tsx
+++ b/src/components/layout/site-header.tsx
@@ -114,7 +114,7 @@ export function SiteHeader() {
 
         <nav className="hidden items-center gap-8 text-sm font-semibold text-slate-600 lg:flex">
           {navigation.main.map((item) => {
-            if (item.items) {
+            if ("items" in item && item.items) {
               return (
                 <div
                   key={item.label}


### PR DESCRIPTION
## Summary
- ensure navigation dropdown detection uses an `in` operator type guard before accessing `items`

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5d37471c4832ea1b53660cef7dcd9