### PR TITLE
Fix LocalBusiness JSON-LD address generation

### DIFF
--- a/src/components/seo/local-business-jsonld.tsx
+++ b/src/components/seo/local-business-jsonld.tsx
@@ -1,13 +1,17 @@
 import { siteConfig } from "@/config/site";
 
 export function LocalBusinessJsonLd() {
-  const addresses = siteConfig.locations.map((location) => ({
-    '@type': 'PostalAddress',
-    streetAddress: location.address,
-    addressLocality: location.city,
-    addressRegion: 'FL',
-    addressCountry: 'US'
-  }));
+  const hq = siteConfig.headquarters;
+  const addresses = [
+    {
+      '@type': 'PostalAddress',
+      streetAddress: hq.street,
+      addressLocality: hq.city,
+      addressRegion: hq.state,
+      postalCode: hq.postalCode,
+      addressCountry: 'US'
+    }
+  ];
 
   const payload = {
     '@context': 'https://schema.org',


### PR DESCRIPTION
## Summary
- read the local business JSON-LD address data from the headquarters entry in siteConfig
- build a single postal address payload and continue to support the single-or-array JSON-LD shape

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e057acd8832ea0a7ef63f351b03c